### PR TITLE
[Issue#7]: Use collection and iterator, saveAttribute for items

### DIFF
--- a/Service/ConnectorInterface.php
+++ b/Service/ConnectorInterface.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Copyright Elgentos BV. All rights reserved.
+ * https://www.elgentos.nl/
+ */
+
+namespace Elgentos\LinkGuestOrdersToCustomer\Service;
+
+interface ConnectorInterface
+{
+    /**
+     * Return number of affected orders for given email address
+     *
+     * @param string|null $email
+     * @return int
+     */
+    public function connect(?string $email = ''): int;
+}


### PR DESCRIPTION
Fix #7 

## Changes ##
- Use Collection and iterator
- Use saveAttribute for saving the order attributes
- Remove deprecated purchase for downloadable products since Magento prevent to checkout as guest if there is any  downloadable products on cart.
- Backward compatibility with PHP7.3